### PR TITLE
CucumberOptions are not read.

### DIFF
--- a/core/src/main/java/cucumber/runtime/arquillian/ArquillianCucumber.java
+++ b/core/src/main/java/cucumber/runtime/arquillian/ArquillianCucumber.java
@@ -142,7 +142,7 @@ public class ArquillianCucumber extends Arquillian {
         }
 
         final RuntimeOptions runtimeOptions;
-        if (clazz.getAnnotation(Cucumber.Options.class) != null) { // by class setting
+        if (clazz.getAnnotation(Cucumber.Options.class) != null || clazz.getAnnotation(CucumberOptions.class) != null) { // by class setting
             final RuntimeOptionsFactory runtimeOptionsFactory = new RuntimeOptionsFactory(clazz, OPTIONS_ANNOTATIONS);
             runtimeOptions = runtimeOptionsFactory.create();
             cleanClasspathList(runtimeOptions.getGlue());


### PR DESCRIPTION
Only the deprecated Cucumber.Options annotation is recognized. If only CucumberOptions is available the runtimeoptions are never initialized.
