### PR TITLE
Asciidoc reports configuration

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -15,7 +15,7 @@
   <properties>
     <asciidoctorj.version>1.5.2</asciidoctorj.version>
     <asciidoctorj-pdf.version>1.5.0-alpha.8</asciidoctorj-pdf.version>
-    <cukedoctor.version>0.4.0</cukedoctor.version>
+    <cukedoctor.version>0.4.1</cukedoctor.version>
   </properties>
 
   <dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -135,6 +135,12 @@
       <version>${asciidoctorj-pdf.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <version>1.15</version>
+    </dependency>
+
 
     <dependency>
       <groupId>org.jboss.arquillian.junit</groupId>

--- a/core/src/main/java/cucumber/runtime/arquillian/client/CucumberArchiveProcessor.java
+++ b/core/src/main/java/cucumber/runtime/arquillian/client/CucumberArchiveProcessor.java
@@ -84,7 +84,7 @@ public class CucumberArchiveProcessor implements ApplicationArchiveProcessor {
         final JavaArchive resourceJar = create(JavaArchive.class, "cukespace-resources.jar");
 
         final CucumberConfiguration cucumberConfiguration = configuration.get();
-        final boolean report = cucumberConfiguration.isReport();
+        final boolean report = cucumberConfiguration.isReport() || cucumberConfiguration.getReportConfig() != null;
         final String reportDirectory = cucumberConfiguration.getReportDirectory();
 
         addFeatures(featureUrls, ln, resourceJar);

--- a/core/src/main/java/cucumber/runtime/arquillian/client/CucumberConfigurationProducer.java
+++ b/core/src/main/java/cucumber/runtime/arquillian/client/CucumberConfigurationProducer.java
@@ -1,49 +1,57 @@
 package cucumber.runtime.arquillian.client;
 
 import cucumber.runtime.arquillian.config.CucumberConfiguration;
+import cucumber.runtime.arquillian.reporter.ReportAttributes;
+import cucumber.runtime.arquillian.reporter.ReportConfig;
 import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
 import org.jboss.arquillian.config.descriptor.api.ExtensionDef;
 import org.jboss.arquillian.core.api.InstanceProducer;
 import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
 import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.arquillian.core.api.annotation.Observes;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
 
 import java.util.Map;
 
 public class CucumberConfigurationProducer {
-    @Inject @ApplicationScoped
+    @Inject
+    @ApplicationScoped
     private InstanceProducer<CucumberConfiguration> configurationProducer;
 
     public void findConfiguration(final @Observes ArquillianDescriptor descriptor) {
         final ExtensionDef cucumberDef = descriptor.extension("cucumber");
         CucumberConfiguration config = CucumberConfiguration.from(cucumberDef.getExtensionProperties());
         configurationProducer.set(config);
-        ExtensionDef adocExtension = descriptor.extension("cucumber-report-adoc");
-        if(adocExtension != null) {
-            configAdocExtension(adocExtension, config);
+        ExtensionDef reportExtension = descriptor.extension("cucumber-report");
+        if (reportExtension != null) {
+            configReportExtension(reportExtension, config);
         }
     }
 
-    private void configAdocExtension(ExtensionDef adocExtension, CucumberConfiguration config) {
-            Map<String, String> adocReportConfig = config.getConfig("adoc.doc.attributes");
+    private void configReportExtension(ExtensionDef reportExtension, CucumberConfiguration config) {
+        ReportConfig reportConfig = new ReportConfig();
+        Map<String, String> props = reportExtension.getExtensionProperties();
+        String dir = props.get("directory");
+        if (dir != null) {
+            reportConfig.setDirectory(dir);
+        }
 
-            for (String s : adocExtension.getExtensionProperties().keySet()) {
-                /**
-                 <property name="attributes">
-                 linkcss = true,
-                 icons = font
-                 </property>
-                 */
-                if(s.equals("attributes")) {
-                    String[] attrs = adocExtension.getExtensionProperties().get(s).replaceAll("\\s", "").split(",");
-                    for (String attr : attrs) {
-                        if (!attr.contains("=")) {
-                            continue;
-                        }
-                        adocReportConfig.put("adoc.doc.attributes." + attr.split("=")[0], attr.split("=")[1]);
-                    }
-                }
+        String formats = props.get("formats");
+        if (formats != null) {
+            reportConfig.setFormats(formats.split(","));
+        }
+        String attrs = props.get("attributes");
+        if(attrs != null){
+            if(attrs.contains("\t")){
+                attrs = attrs.replaceAll("\t","");
             }
-        config.putConfig(adocReportConfig);
+            Yaml yaml = new Yaml(new Constructor(ReportAttributes.class));
+            ReportAttributes reportAttributes = (ReportAttributes) yaml.load(attrs);
+            reportConfig.setReportAttributes(reportAttributes);
+        }
+
+        config.setReportConfig(reportConfig);
+
     }
 }

--- a/core/src/main/java/cucumber/runtime/arquillian/client/CucumberConfigurationProducer.java
+++ b/core/src/main/java/cucumber/runtime/arquillian/client/CucumberConfigurationProducer.java
@@ -8,12 +8,42 @@ import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
 import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.arquillian.core.api.annotation.Observes;
 
+import java.util.Map;
+
 public class CucumberConfigurationProducer {
     @Inject @ApplicationScoped
     private InstanceProducer<CucumberConfiguration> configurationProducer;
 
     public void findConfiguration(final @Observes ArquillianDescriptor descriptor) {
         final ExtensionDef cucumberDef = descriptor.extension("cucumber");
-        configurationProducer.set(CucumberConfiguration.from(cucumberDef.getExtensionProperties()));
+        CucumberConfiguration config = CucumberConfiguration.from(cucumberDef.getExtensionProperties());
+        configurationProducer.set(config);
+        ExtensionDef adocExtension = descriptor.extension("cucumber-report-adoc");
+        if(adocExtension != null) {
+            configAdocExtension(adocExtension, config);
+        }
+    }
+
+    private void configAdocExtension(ExtensionDef adocExtension, CucumberConfiguration config) {
+            Map<String, String> adocReportConfig = config.getConfig("adoc.doc.attributes");
+
+            for (String s : adocExtension.getExtensionProperties().keySet()) {
+                /**
+                 <property name="attributes">
+                 linkcss = true,
+                 icons = font
+                 </property>
+                 */
+                if(s.equals("attributes")) {
+                    String[] attrs = adocExtension.getExtensionProperties().get(s).replaceAll("\\s", "").split(",");
+                    for (String attr : attrs) {
+                        if (!attr.contains("=")) {
+                            continue;
+                        }
+                        adocReportConfig.put("adoc.doc.attributes." + attr.split("=")[0], attr.split("=")[1]);
+                    }
+                }
+            }
+        config.putConfig(adocReportConfig);
     }
 }

--- a/core/src/main/java/cucumber/runtime/arquillian/config/CucumberConfiguration.java
+++ b/core/src/main/java/cucumber/runtime/arquillian/config/CucumberConfiguration.java
@@ -1,5 +1,7 @@
 package cucumber.runtime.arquillian.config;
 
+import cucumber.runtime.arquillian.reporter.ReportConfig;
+
 import java.io.File;
 import java.util.HashMap;
 import java.util.Locale;
@@ -17,13 +19,12 @@ public class CucumberConfiguration {
     public static final String FEATURE_HOME = "featureHome";
 
     private boolean report;
-    private boolean generateDocs;
     private boolean colorized;
     private boolean initialized;
     private String reportDirectory;
-    private String docsDirectory;
     private String options;
     private String featureHome;
+    private ReportConfig reportConfig;
 
     /**
      * directory to dump resource loader from loaders
@@ -75,13 +76,6 @@ public class CucumberConfiguration {
         return report;
     }
 
-    public boolean isGenerateDocs() {
-        return generateDocs;
-    }
-
-    public String getDocsDirectory() {
-        return docsDirectory;
-    }
 
     public String getReportDirectory() {
         return reportDirectory;
@@ -105,6 +99,14 @@ public class CucumberConfiguration {
 
     public String getFeatureHome() {
         return featureHome;
+    }
+
+    public ReportConfig getReportConfig() {
+        return reportConfig;
+    }
+
+    public void setReportConfig(ReportConfig reportConfig) {
+        this.reportConfig = reportConfig;
     }
 
     public boolean arePersistenceEventsActivated() {
@@ -132,13 +134,6 @@ public class CucumberConfiguration {
                 CONFIGURATION.reportDirectory = properties.get("reportDirectory");
             }
 
-            if (properties.containsKey("generateDocs")) {
-                CONFIGURATION.generateDocs = Boolean.parseBoolean(properties.get("generateDocs"));
-            }
-
-            if (properties.containsKey("docsDirectory")) {
-                CONFIGURATION.docsDirectory = properties.get("docsDirectory");
-            }
 
             if (properties.containsKey(COLORS)) {
                 CONFIGURATION.colorized = Boolean.parseBoolean(properties.get(COLORS));
@@ -161,11 +156,9 @@ public class CucumberConfiguration {
         CONFIGURATION.persistenceEventsActivated = false;
         CONFIGURATION.initialized = false;
         CONFIGURATION.reportDirectory = "target/cucumber-report/";
-        CONFIGURATION.docsDirectory = "target/docs/";
         CONFIGURATION.tempDir = guessDefaultTempDir();
         CONFIGURATION.options = null;
         CONFIGURATION.report = false;
-        CONFIGURATION.generateDocs = false;
         CONFIGURATION.colorized = !System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("win")
                                         && !System.getProperty("java.class.path").contains("idea_rt");
     }

--- a/core/src/main/java/cucumber/runtime/arquillian/config/CucumberConfiguration.java
+++ b/core/src/main/java/cucumber/runtime/arquillian/config/CucumberConfiguration.java
@@ -67,6 +67,10 @@ public class CucumberConfiguration {
         return config;
     }
 
+    public void putConfig(Map<String,String> attrs){
+        original.putAll(attrs);
+    }
+
     public boolean isReport() {
         return report;
     }

--- a/core/src/main/java/cucumber/runtime/arquillian/reporter/CucumberReporter.java
+++ b/core/src/main/java/cucumber/runtime/arquillian/reporter/CucumberReporter.java
@@ -98,9 +98,10 @@ public class CucumberReporter {
                     CukedoctorConverter converter = Cukedoctor.instance(features, da);
                     String report = converter.renderDocumentation();
 
-                    String destDir = reportConfig.getDirectory();
+
                     Asciidoctor asciidoctor = Asciidoctor.Factory.create();
                     for (String format : reportConfig.getFormats()) {
+                        String destDir = reportConfig.getDirectory();
                         final OptionsBuilder optBuilder = OptionsBuilder.options()
                                 //.destinationDir(destDir)
                                 .backend(format)
@@ -139,8 +140,9 @@ public class CucumberReporter {
                         File adocFile = FileUtil.saveFile(destDir + "/"+reportConfig.getFileName() + ".adoc", report);
                         if(!format.equals("adoc")){//there is no adoc backend
                             asciidoctor.convertFile(adocFile, optBuilder.asMap());
+                            adocFile.deleteOnExit();
                         }
-                        LOGGER.info("Cucumber report available at " + adocFile.getParent() + "/"+reportConfig.getFileName()+"."+format);
+                        LOGGER.info("Cucumber report available at " + adocFile.getParent() + "/" + reportConfig.getFileName() + "." + format);
                     }
 
                     asciidoctor.shutdown();

--- a/core/src/main/java/cucumber/runtime/arquillian/reporter/CucumberReporter.java
+++ b/core/src/main/java/cucumber/runtime/arquillian/reporter/CucumberReporter.java
@@ -27,7 +27,6 @@ import java.util.*;
 import java.util.logging.Logger;
 
 import static java.util.Arrays.asList;
-import static java.util.Arrays.binarySearch;
 
 public class CucumberReporter {
     private static final Logger LOGGER = Logger.getLogger(CucumberReporter.class.getName());
@@ -107,6 +106,12 @@ public class CucumberReporter {
                     final Map<String, String> opts = configuration.get().getConfig("adoc.options.");
                     if (!opts.isEmpty()) {
                         bind(opts, optBuilder);
+                    }
+                    String[] formats = null;
+                    if(opts.containsKey("formats")){
+                        formats = opts.get("formats").split(",");
+                    }else{
+                        formats = new String[]{"html5"};
                     }
 
                     final Map<String, String> attrs = configuration.get().getConfig("adoc.attributes.");

--- a/core/src/main/java/cucumber/runtime/arquillian/reporter/CucumberReporter.java
+++ b/core/src/main/java/cucumber/runtime/arquillian/reporter/CucumberReporter.java
@@ -102,6 +102,7 @@ public class CucumberReporter {
                     Asciidoctor asciidoctor = Asciidoctor.Factory.create();
                     for (String format : reportConfig.getFormats()) {
                         String destDir = reportConfig.getDirectory();
+                        String fileName = reportConfig.getFileName();
                         final OptionsBuilder optBuilder = OptionsBuilder.options()
                                 //.destinationDir(destDir)
                                 .backend(format)
@@ -115,6 +116,9 @@ public class CucumberReporter {
                                     destDir = (String) reportConfig.getHtmlAttribute("directory");
                                     //optBuilder.destinationDir(destDir);
                                 }
+                                if(reportConfig.getHtmlAttribute("fileName") != null){
+                                   fileName = (String) reportConfig.getHtmlAttribute("fileName");
+                                }
                             }
                         }
 
@@ -124,6 +128,9 @@ public class CucumberReporter {
                                 if(reportConfig.getAdocAttribute("directory") != null){
                                     destDir = (String) reportConfig.getAdocAttribute("directory");
                                    // optBuilder.destinationDir(destDir);
+                                }
+                                if(reportConfig.getAdocAttribute("fileName") != null){
+                                    fileName = (String) reportConfig.getAdocAttribute("fileName");
                                 }
                             }
                         }
@@ -135,9 +142,12 @@ public class CucumberReporter {
                                     destDir = (String) reportConfig.getPdfAttribute("directory");
                                     //optBuilder.destinationDir(destDir);
                                 }
+                                if(reportConfig.getPdfAttribute("fileName") != null){
+                                    fileName = (String) reportConfig.getPdfAttribute("fileName");
+                                }
                             }
                         }
-                        File adocFile = FileUtil.saveFile(destDir + "/"+reportConfig.getFileName() + ".adoc", report);
+                        File adocFile = FileUtil.saveFile(destDir + "/"+fileName + ".adoc", report);
                         if(!format.equals("adoc")){//there is no adoc backend
                             asciidoctor.convertFile(adocFile, optBuilder.asMap());
                             adocFile.deleteOnExit();

--- a/core/src/main/java/cucumber/runtime/arquillian/reporter/CucumberReporter.java
+++ b/core/src/main/java/cucumber/runtime/arquillian/reporter/CucumberReporter.java
@@ -97,7 +97,7 @@ public class CucumberReporter {
                     final DocumentAttributes da = new DocumentAttributes();
                     CukedoctorConverter converter = Cukedoctor.instance(features, da);
                     String report = converter.renderDocumentation();
-
+                    Asciidoctor asciidoctor = null;
                     for (String format : reportConfig.getFormats()) {
                         String destDir = reportConfig.getDirectory();
                         String fileName = reportConfig.getFileName();
@@ -147,15 +147,18 @@ public class CucumberReporter {
                         }
                         File adocFile = FileUtil.saveFile(destDir + "/"+fileName + ".adoc", report);
                         if(!format.equals("adoc")){//there is no adoc backend
-                            Asciidoctor asciidoctor = Asciidoctor.Factory.create();
+                            if(asciidoctor == null){
+                                asciidoctor = Asciidoctor.Factory.create();
+                            }
                             asciidoctor.convertFile(adocFile, optBuilder.asMap());
-                            asciidoctor.shutdown();
                             adocFile.deleteOnExit();
                         }
                         LOGGER.info("Cucumber report available at " + adocFile.getParent() + "/" + fileName + "." + format);
                     }
 
-
+                    if(asciidoctor != null){
+                        asciidoctor.shutdown();
+                    }
 
                 }
             }

--- a/core/src/main/java/cucumber/runtime/arquillian/reporter/CucumberReporter.java
+++ b/core/src/main/java/cucumber/runtime/arquillian/reporter/CucumberReporter.java
@@ -98,8 +98,6 @@ public class CucumberReporter {
                     CukedoctorConverter converter = Cukedoctor.instance(features, da);
                     String report = converter.renderDocumentation();
 
-
-                    Asciidoctor asciidoctor = Asciidoctor.Factory.create();
                     for (String format : reportConfig.getFormats()) {
                         String destDir = reportConfig.getDirectory();
                         String fileName = reportConfig.getFileName();
@@ -149,13 +147,15 @@ public class CucumberReporter {
                         }
                         File adocFile = FileUtil.saveFile(destDir + "/"+fileName + ".adoc", report);
                         if(!format.equals("adoc")){//there is no adoc backend
+                            Asciidoctor asciidoctor = Asciidoctor.Factory.create();
                             asciidoctor.convertFile(adocFile, optBuilder.asMap());
+                            asciidoctor.shutdown();
                             adocFile.deleteOnExit();
                         }
-                        LOGGER.info("Cucumber report available at " + adocFile.getParent() + "/" + reportConfig.getFileName() + "." + format);
+                        LOGGER.info("Cucumber report available at " + adocFile.getParent() + "/" + fileName + "." + format);
                     }
 
-                    asciidoctor.shutdown();
+
 
                 }
             }

--- a/core/src/main/java/cucumber/runtime/arquillian/reporter/ReportAttributes.java
+++ b/core/src/main/java/cucumber/runtime/arquillian/reporter/ReportAttributes.java
@@ -2,9 +2,6 @@ package cucumber.runtime.arquillian.reporter;
 
 import java.util.Map;
 
-/**
- * Created by pestano on 12/07/15.
- */
 public class ReportAttributes {
 
     private Map<String,Object> adocAtributes;

--- a/core/src/main/java/cucumber/runtime/arquillian/reporter/ReportAttributes.java
+++ b/core/src/main/java/cucumber/runtime/arquillian/reporter/ReportAttributes.java
@@ -1,0 +1,40 @@
+package cucumber.runtime.arquillian.reporter;
+
+import java.util.Map;
+
+/**
+ * Created by pestano on 12/07/15.
+ */
+public class ReportAttributes {
+
+    private Map<String,Object> adocAtributes;
+    private Map<String,Object> htmlAtributes;
+    private Map<String,Object> pdfAtributes;
+
+    public ReportAttributes() {
+    }
+
+    public Map<String, Object> getAdocAtributes() {
+        return adocAtributes;
+    }
+
+    public void setAdocAtributes(Map<String, Object> adocAtributes) {
+        this.adocAtributes = adocAtributes;
+    }
+
+    public Map<String, Object> getHtmlAtributes() {
+        return htmlAtributes;
+    }
+
+    public void setHtmlAtributes(Map<String, Object> htmlAtributes) {
+        this.htmlAtributes = htmlAtributes;
+    }
+
+    public Map<String, Object> getPdfAtributes() {
+        return pdfAtributes;
+    }
+
+    public void setPdfAtributes(Map<String, Object> pdfAtributes) {
+        this.pdfAtributes = pdfAtributes;
+    }
+}

--- a/core/src/main/java/cucumber/runtime/arquillian/reporter/ReportConfig.java
+++ b/core/src/main/java/cucumber/runtime/arquillian/reporter/ReportConfig.java
@@ -5,7 +5,7 @@ import java.io.Serializable;
 public class ReportConfig implements Serializable {
 
     private String directory = "target/cucumber-report/";
-    private String[] formats = new String[]{"html5"};
+    private String[] formats = new String[]{"html"};
     private ReportAttributes reportAttributes = new ReportAttributes();
     private String fileName = "report"; //report output filename
 

--- a/core/src/main/java/cucumber/runtime/arquillian/reporter/ReportConfig.java
+++ b/core/src/main/java/cucumber/runtime/arquillian/reporter/ReportConfig.java
@@ -2,9 +2,6 @@ package cucumber.runtime.arquillian.reporter;
 
 import java.io.Serializable;
 
-/**
- * Created by pestano on 12/07/15.
- */
 public class ReportConfig implements Serializable {
 
     private String directory = "target/cucumber-report/";

--- a/core/src/main/java/cucumber/runtime/arquillian/reporter/ReportConfig.java
+++ b/core/src/main/java/cucumber/runtime/arquillian/reporter/ReportConfig.java
@@ -1,0 +1,76 @@
+package cucumber.runtime.arquillian.reporter;
+
+import java.io.Serializable;
+
+/**
+ * Created by pestano on 12/07/15.
+ */
+public class ReportConfig implements Serializable {
+
+    private String directory = "target/cucumber-report/";
+    private String[] formats = new String[]{"html5"};
+    private ReportAttributes reportAttributes = new ReportAttributes();
+    private String fileName = "report"; //report output filename
+
+    public String getDirectory() {
+        return directory;
+    }
+
+    public void setDirectory(String directory) {
+        this.directory = directory;
+    }
+
+    public String[] getFormats() {
+        return formats;
+    }
+
+    public void setFormats(String[] formats) {
+        this.formats = formats;
+    }
+
+    public ReportAttributes getReportAttributes() {
+        return reportAttributes;
+    }
+
+    public void setReportAttributes(ReportAttributes reportAttributes) {
+        this.reportAttributes = reportAttributes;
+    }
+
+    public boolean hasAdocConfig() {
+        return reportAttributes != null &&
+                reportAttributes.getAdocAtributes() != null &&
+                !reportAttributes.getAdocAtributes().isEmpty();
+    }
+
+    public boolean hasHtmlConfig() {
+        return reportAttributes != null &&
+                reportAttributes.getHtmlAtributes() != null &&
+                !reportAttributes.getHtmlAtributes().isEmpty();
+    }
+
+    public boolean hasPdfConfig() {
+        return reportAttributes != null &&
+                reportAttributes.getPdfAtributes() != null &&
+                !reportAttributes.getPdfAtributes().isEmpty();
+    }
+
+    public Object getAdocAttribute(String key) {
+        return hasAdocConfig() ? getReportAttributes().getAdocAtributes().get(key) : null;
+    }
+
+    public Object getHtmlAttribute(String key) {
+        return hasHtmlConfig() ? getReportAttributes().getHtmlAtributes().get(key) : null;
+    }
+
+    public Object getPdfAttribute(String key) {
+        return hasPdfConfig() ? getReportAttributes().getPdfAtributes().get(key) : null;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+}

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -214,6 +214,10 @@
           <groupId>org.mortbay.jetty</groupId>
           <artifactId>servlet-api-2.5</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.yaml</groupId>
+          <artifactId>snakeyaml</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/examples/src/test/java/cucumber/runtime/arquillian/feature/PortugueseTest.java
+++ b/examples/src/test/java/cucumber/runtime/arquillian/feature/PortugueseTest.java
@@ -1,9 +1,7 @@
 package cucumber.runtime.arquillian.feature;
 
 import cucumber.api.CucumberOptions;
-import cucumber.api.PendingException;
 import cucumber.api.java.pt.Dado;
-import cucumber.api.java.pt.E;
 import cucumber.api.java.pt.Entao;
 import cucumber.api.java.pt.Quando;
 import cucumber.runtime.arquillian.ArquillianCucumber;
@@ -46,9 +44,4 @@ public class PortugueseTest {
         assertEquals(3, calls);
     }
 
-    @E("^I add a pending step$")
-    public void I_add_a_pending_step() throws Throwable {
-        // Express the Regexp above with the code you wish you had
-        throw new PendingException();
-    }
 }

--- a/examples/src/test/java/cucumber/runtime/arquillian/feature/PortugueseTest.java
+++ b/examples/src/test/java/cucumber/runtime/arquillian/feature/PortugueseTest.java
@@ -1,7 +1,9 @@
 package cucumber.runtime.arquillian.feature;
 
 import cucumber.api.CucumberOptions;
+import cucumber.api.PendingException;
 import cucumber.api.java.pt.Dado;
+import cucumber.api.java.pt.E;
 import cucumber.api.java.pt.Entao;
 import cucumber.api.java.pt.Quando;
 import cucumber.runtime.arquillian.ArquillianCucumber;
@@ -42,5 +44,11 @@ public class PortugueseTest {
     @AfterClass
     public static void checkCalls() {
         assertEquals(3, calls);
+    }
+
+    @E("^I add a pending step$")
+    public void I_add_a_pending_step() throws Throwable {
+        // Express the Regexp above with the code you wish you had
+        throw new PendingException();
     }
 }

--- a/examples/src/test/resources/arquillian.xml
+++ b/examples/src/test/resources/arquillian.xml
@@ -18,10 +18,11 @@
 
   <extension qualifier="cucumber-report">
     <property name="directory">target/cucumber-report</property>
-    <property name="formats">html,pdf, adoc</property>
+    <property name="formats">html,adoc,pdf</property>
     <property name="attributes">
 	  adocAtributes: {
-        directory: target/cucumber-report-adoc
+        directory: target/docs,
+        fileName: documentation
       }
 	  htmlAtributes: {
         icons: font,
@@ -29,7 +30,9 @@
         directory: target/cucumber-report-html,
         imagesdir: img/
 	  }
-	  pdfAtributes: {}
+	  pdfAtributes: {
+        directory: target/cucumber-report-pdf
+      }
     </property>
   </extension>
 

--- a/examples/src/test/resources/arquillian.xml
+++ b/examples/src/test/resources/arquillian.xml
@@ -16,6 +16,23 @@
     <property name="persistenceEventsActivated">true</property>
   </extension>
 
+  <extension qualifier="cucumber-report-adoc">
+    <property name="directory">target/cucumber-report-adoc</property>
+    <property name="directory-html">target/cucumber-report-html</property> <!-- = directory if not specified -->
+    <property name="directory-pdf">target/cucumber-report-pdf</property>
+    <property name="formats">adoc,html,pdf</property>
+    <property name="attributes"> <!-- defaults shared accross all rendering -->
+      linkcss =
+      custom-attr = custom-val
+    </property>
+    <property name="attributes-html">
+      imagesdir = img/
+    </property>
+    <property name="attributes-pdf">
+
+    </property>
+  </extension>
+
   <extension qualifier="webdriver">
     <property name="browser">chrome</property>
     <property name="remoteAddress">http://localhost:4444/wd/hub/</property>

--- a/examples/src/test/resources/arquillian.xml
+++ b/examples/src/test/resources/arquillian.xml
@@ -18,13 +18,15 @@
 
   <extension qualifier="cucumber-report">
     <property name="directory">target/cucumber-report</property>
-    <property name="formats">html</property>
+    <property name="formats">html,pdf, adoc</property>
     <property name="attributes">
 	  adocAtributes: {
         directory: target/cucumber-report-adoc
       }
 	  htmlAtributes: {
         icons: font,
+        toc: right,
+        directory: target/cucumber-report-html,
         imagesdir: img/
 	  }
 	  pdfAtributes: {}

--- a/examples/src/test/resources/arquillian.xml
+++ b/examples/src/test/resources/arquillian.xml
@@ -16,20 +16,18 @@
     <property name="persistenceEventsActivated">true</property>
   </extension>
 
-  <extension qualifier="cucumber-report-adoc">
-    <property name="directory">target/cucumber-report-adoc</property>
-    <property name="directory-html">target/cucumber-report-html</property> <!-- = directory if not specified -->
-    <property name="directory-pdf">target/cucumber-report-pdf</property>
-    <property name="formats">adoc,html,pdf</property>
-    <property name="attributes"> <!-- defaults shared accross all rendering -->
-      linkcss = true,
-      icons = font
-    </property>
-    <property name="attributes-html">
-      imagesdir = img/
-    </property>
-    <property name="attributes-pdf">
-
+  <extension qualifier="cucumber-report">
+    <property name="directory">target/cucumber-report</property>
+    <property name="formats">html</property>
+    <property name="attributes">
+	  adocAtributes: {
+        directory: target/cucumber-report-adoc
+      }
+	  htmlAtributes: {
+        icons: font,
+        imagesdir: img/
+	  }
+	  pdfAtributes: {}
     </property>
   </extension>
 

--- a/examples/src/test/resources/arquillian.xml
+++ b/examples/src/test/resources/arquillian.xml
@@ -22,8 +22,8 @@
     <property name="directory-pdf">target/cucumber-report-pdf</property>
     <property name="formats">adoc,html,pdf</property>
     <property name="attributes"> <!-- defaults shared accross all rendering -->
-      linkcss =
-      custom-attr = custom-val
+      linkcss = true,
+      icons = font
     </property>
     <property name="attributes-html">
       imagesdir = img/

--- a/examples/src/test/resources/cucumber/runtime/arquillian/feature/portuguese.feature
+++ b/examples/src/test/resources/cucumber/runtime/arquillian/feature/portuguese.feature
@@ -5,5 +5,4 @@ Funcionalidade: Fazer login no sistema
   Cenario: Usuário e senha corretos
     Dado O sistema possui o usuario 'admin' cadastrado
     Quando O usuario preenche o login como 'admin' e a senha O botao de login é clicado
-    E I add a pending step
     Entao O usuário é redirecionado para a página de pesquisa de usuarios

--- a/examples/src/test/resources/cucumber/runtime/arquillian/feature/portuguese.feature
+++ b/examples/src/test/resources/cucumber/runtime/arquillian/feature/portuguese.feature
@@ -5,4 +5,5 @@ Funcionalidade: Fazer login no sistema
   Cenario: Usuário e senha corretos
     Dado O sistema possui o usuario 'admin' cadastrado
     Quando O usuario preenche o login como 'admin' e a senha O botao de login é clicado
+    E I add a pending step
     Entao O usuário é redirecionado para a página de pesquisa de usuarios


### PR DESCRIPTION
refers to issue #55.

Using arquillian.xml extension qualifier with name **cucumber-report** to customize reports options.

Note that current report solution (by Master thought) is not ported to this new format yet.

