### PR TITLE
upgraded cucumber-reporting version to 1.2.0

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -74,7 +74,7 @@
     <dependency>
       <groupId>net.masterthought</groupId>
       <artifactId>cucumber-reporting</artifactId>
-      <version>0.1.0</version>
+      <version>0.6.0</version>
       <exclusions>
         <exclusion>
           <groupId>commons-collections</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -74,7 +74,7 @@
     <dependency>
       <groupId>net.masterthought</groupId>
       <artifactId>cucumber-reporting</artifactId>
-      <version>0.6.0</version>
+      <version>1.2.0</version>
       <exclusions>
         <exclusion>
           <groupId>commons-collections</groupId>

--- a/core/src/main/java/cucumber/runtime/arquillian/reporter/CucumberReporter.java
+++ b/core/src/main/java/cucumber/runtime/arquillian/reporter/CucumberReporter.java
@@ -74,7 +74,7 @@ public class CucumberReporter {
             try {
                 new ReportBuilder(new ArrayList<String>(jsonReports),
                                 outputDir, "/", "#", findProjectName(),
-                                false, false, false, false, true, false, false, "", true, false)
+                                false, false, false, false, true, false, true, false)
                         .generateReports();
 
                 LOGGER.info("Cucumber report available at "

--- a/core/src/main/java/cucumber/runtime/arquillian/reporter/CucumberReporter.java
+++ b/core/src/main/java/cucumber/runtime/arquillian/reporter/CucumberReporter.java
@@ -7,6 +7,7 @@ import com.github.cukedoctor.api.model.Feature;
 import com.github.cukedoctor.parser.FeatureParser;
 import com.github.cukedoctor.util.FileUtil;
 import cucumber.runtime.arquillian.config.CucumberConfiguration;
+import net.masterthought.cucumber.Configuration;
 import net.masterthought.cucumber.ReportBuilder;
 import org.asciidoctor.Asciidoctor;
 import org.asciidoctor.AttributesBuilder;
@@ -71,17 +72,19 @@ public class CucumberReporter {
 
         { // generate the report
             final File outputDir = new File(configuration.get().getReportDirectory());
-            try {
-                new ReportBuilder(new ArrayList<String>(jsonReports),
-                                outputDir, "/", "#", findProjectName(),
-                                false, false, false, false, true, false, true, false)
-                        .generateReports();
 
-                LOGGER.info("Cucumber report available at "
-                        + new File(outputDir, "feature-overview.html").getAbsolutePath());
-            } catch (final Exception e) {
-                throw new IllegalArgumentException(e);
-            }
+            final Configuration reportConfiguration = new Configuration(outputDir, findProjectName());
+            reportConfiguration.setStatusFlags(false, false, false, false);
+            reportConfiguration.setBuildNumber("1");
+            reportConfiguration.setParallelTesting(false);
+            reportConfiguration.setRunWithJenkins(false);
+            reportConfiguration.setJenkinsBasePath("");
+
+            new ReportBuilder(new ArrayList<String>(jsonReports), reportConfiguration)
+                    .generateReports();
+
+            LOGGER.info("Cucumber report available at "
+                    + new File(outputDir, "feature-overview.html").getAbsolutePath());
         }
 
         {//generate documentation using cukedoctor and asciidoctor

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -198,6 +198,10 @@
           <groupId>xml-apis</groupId>
           <artifactId>xml-apis</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-lang3</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
Upgraded cucumber-reporting to 0.6.0 which no longer depends on the totallylazy artifact. Totallylazy is not in the Maven repositories. 