### PR TITLE
#91 Cdi support with object factory

### DIFF
--- a/core/src/main/java/cucumber/runtime/arquillian/backend/ArquillianBackend.java
+++ b/core/src/main/java/cucumber/runtime/arquillian/backend/ArquillianBackend.java
@@ -193,11 +193,9 @@ public class ArquillianBackend extends JavaBackend implements Backend {
 
                 if (readFromJava(clazz)) {
                     glueType = GlueType.JAVA;
-                    break;
                 }
                 if (readFromScalaDsl(objectFactory.getInstance(clazz)) && glueType != GlueType.JAVA) {
                     glueType = GlueType.SCALA;
-                    break;
                 }
             }
             if (glueType != GlueType.UNKNOWN) {

--- a/core/src/main/java/cucumber/runtime/arquillian/client/CucumberArchiveProcessor.java
+++ b/core/src/main/java/cucumber/runtime/arquillian/client/CucumberArchiveProcessor.java
@@ -126,10 +126,11 @@ public class CucumberArchiveProcessor implements ApplicationArchiveProcessor {
         final CucumberConfiguration cucumberConfiguration = configuration.get();
         final boolean report = cucumberConfiguration.isReport() || cucumberConfiguration.isGenerateDocs();
         final String reportDirectory = cucumberConfiguration.getReportDirectory();
+        final String objectFactory = cucumberConfiguration.getObjectFactory();
 
         addFeatures(featureUrls, ln, resourceJar);
         addCucumberAnnotations(ln, resourceJar);
-        addConfiguration(resourceJar, cucumberConfiguration, report, reportDirectory);
+        addConfiguration(resourceJar, cucumberConfiguration, report, reportDirectory, objectFactory);
 
         libraryContainer.addAsLibrary(resourceJar);
 
@@ -151,12 +152,16 @@ public class CucumberArchiveProcessor implements ApplicationArchiveProcessor {
         tryToAdd(libs, libraryContainer, "WEB-INF/lib/scala-library-", "cucumber.api.scala.ScalaDsl", "scala.App");
     }
 
-    private static void addConfiguration(final JavaArchive resourceJar, final CucumberConfiguration cucumberConfiguration, final boolean report, final String reportDirectory) {
+    private static void addConfiguration(final JavaArchive resourceJar, final CucumberConfiguration cucumberConfiguration, final boolean report, final String reportDirectory, final String objectFactory) {
         final StringBuilder config = new StringBuilder();
         config.append(CucumberConfiguration.COLORS).append("=").append(cucumberConfiguration.isColorized()).append("\n")
                 .append(CucumberConfiguration.REPORTABLE).append("=").append(report).append("\n")
                 .append(CucumberConfiguration.REPORTABLE_PATH).append("=")
                 .append(reportDirectory == null ? null : new File(reportDirectory).getAbsolutePath()).append("\n");
+
+        if (objectFactory != null) {
+             config.append(CucumberConfiguration.OBJECT_FACTORY).append("=").append(objectFactory).append("\n");
+        }
         if (cucumberConfiguration.hasOptions()) {
             config.append(CucumberConfiguration.OPTIONS).append("=").append(cucumberConfiguration.getOptions());
         }

--- a/core/src/main/java/cucumber/runtime/arquillian/client/CucumberArchiveProcessor.java
+++ b/core/src/main/java/cucumber/runtime/arquillian/client/CucumberArchiveProcessor.java
@@ -126,11 +126,10 @@ public class CucumberArchiveProcessor implements ApplicationArchiveProcessor {
         final CucumberConfiguration cucumberConfiguration = configuration.get();
         final boolean report = cucumberConfiguration.isReport() || cucumberConfiguration.isGenerateDocs();
         final String reportDirectory = cucumberConfiguration.getReportDirectory();
-        final String objectFactory = cucumberConfiguration.getObjectFactory();
 
         addFeatures(featureUrls, ln, resourceJar);
         addCucumberAnnotations(ln, resourceJar);
-        addConfiguration(resourceJar, cucumberConfiguration, report, reportDirectory, objectFactory);
+        addConfiguration(resourceJar, cucumberConfiguration, report, reportDirectory);
 
         libraryContainer.addAsLibrary(resourceJar);
 
@@ -152,15 +151,15 @@ public class CucumberArchiveProcessor implements ApplicationArchiveProcessor {
         tryToAdd(libs, libraryContainer, "WEB-INF/lib/scala-library-", "cucumber.api.scala.ScalaDsl", "scala.App");
     }
 
-    private static void addConfiguration(final JavaArchive resourceJar, final CucumberConfiguration cucumberConfiguration, final boolean report, final String reportDirectory, final String objectFactory) {
+    private static void addConfiguration(final JavaArchive resourceJar, final CucumberConfiguration cucumberConfiguration, final boolean report, final String reportDirectory) {
         final StringBuilder config = new StringBuilder();
         config.append(CucumberConfiguration.COLORS).append("=").append(cucumberConfiguration.isColorized()).append("\n")
                 .append(CucumberConfiguration.REPORTABLE).append("=").append(report).append("\n")
                 .append(CucumberConfiguration.REPORTABLE_PATH).append("=")
                 .append(reportDirectory == null ? null : new File(reportDirectory).getAbsolutePath()).append("\n");
 
-        if (objectFactory != null) {
-             config.append(CucumberConfiguration.OBJECT_FACTORY).append("=").append(objectFactory).append("\n");
+        if (cucumberConfiguration.getObjectFactory() != null) {
+             config.append(CucumberConfiguration.OBJECT_FACTORY).append("=").append(cucumberConfiguration.getObjectFactory()).append("\n");
         }
         if (cucumberConfiguration.hasOptions()) {
             config.append(CucumberConfiguration.OPTIONS).append("=").append(cucumberConfiguration.getOptions());


### PR DESCRIPTION
I encountered some issues, from using the change of #91. 
The `objectFactory` configration was no added in the archive, so `CukeSpaceCDIObjectFactory` could never be loaded.
Another thing was that `ArquillianBackend#scan()` had `break;` in the for loops. When there are multiple glues created, it starts to skip some glues. Then cucumber start reporting that no `@Given`, `@When` or `@Then` is defined.