### PR TITLE
Support EnterpriseArchive CDI

### DIFF
--- a/core/src/main/java/cucumber/runtime/arquillian/client/CucumberArchiveProcessor.java
+++ b/core/src/main/java/cucumber/runtime/arquillian/client/CucumberArchiveProcessor.java
@@ -48,6 +48,7 @@ import static cucumber.runtime.arquillian.shared.ClassLoaders.load;
 import static cucumber.runtime.arquillian.shared.IOs.slurp;
 import static java.util.Arrays.asList;
 import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
@@ -156,7 +157,7 @@ public class CucumberArchiveProcessor implements ApplicationArchiveProcessor {
         enrichWithGlues(javaClass, entryPointContainer, ln);
 
         // cucumber-arquillian
-        enrichWithCukeSpace(entryPointContainer, junit);
+        enrichWithCukeSpace(entryPointContainer, junit, "cdi".equalsIgnoreCase(cucumberConfiguration.getObjectFactory().trim()));
 
         // if scala module is available at classpath
         final Set<ArchivePath> libs = applicationArchive.getContent(new IncludeRegExpPaths("/WEB-INF/lib/.*jar")).keySet();
@@ -247,7 +248,6 @@ public class CucumberArchiveProcessor implements ApplicationArchiveProcessor {
         final StringBuilder gluesStr = new StringBuilder();
         if (!glues.isEmpty()) {
             final JavaArchive gluesJar = create(JavaArchive.class, "cukespace-glues.jar");
-
             { // glues txt file
                 for (final Class<?> g : glues) {
                     gluesStr.append(g.getName()).append(ln);
@@ -272,7 +272,7 @@ public class CucumberArchiveProcessor implements ApplicationArchiveProcessor {
         }
     }
 
-    private static void enrichWithCukeSpace(final LibraryContainer<?> libraryContainer, final boolean junit) {
+    private static void enrichWithCukeSpace(final LibraryContainer<?> libraryContainer, final boolean junit, final boolean cdiEnabled) {
         final JavaArchive archive = create(JavaArchive.class, "cukespace-core.jar")
                 .addAsServiceProvider(RemoteLoadableExtension.class, CucumberContainerExtension.class)
                 .addPackage(ArquillianBackend.class.getPackage())
@@ -284,6 +284,10 @@ public class CucumberArchiveProcessor implements ApplicationArchiveProcessor {
                         Features.class, Glues.class,
                         ContextualObjectFactoryBase.class, CukeSpaceCDIObjectFactory.class)
                 .addPackage(ClientServerFiles.class.getPackage());
+
+        if (cdiEnabled) {
+            archive.addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+        }
         if (junit) {
             archive.addClasses(ArquillianCucumber.class, CukeSpace.class, ArquillianCucumber.InstanceControlledFrameworkMethod.class);
         } else {


### PR DESCRIPTION
I encountered an issue, when I wanted to use the new CDI option with an `EnterpriseArchive`. Because the `EnterpriseArhive` gets enriched with the glues + the cukespace, with CDI this will result in classes that can not be reached.

My solution is to look for a `.war` file in the `EnterpriseArchive`, if it is not found it still falls back to the old logic. You might see I pick "all" `.war` files, but arquillian does not support `EnterpriseArchive` deplyoments with multiple `.war`. 

Not sure if this PR should also check if `objectFactory` is configured to "cdi". Let me know if it needs to be updated.