### PR TITLE
Make CDI as an extension

### DIFF
--- a/core/src/main/java/cucumber/runtime/arquillian/backend/ArquillianBackend.java
+++ b/core/src/main/java/cucumber/runtime/arquillian/backend/ArquillianBackend.java
@@ -14,7 +14,6 @@ import cucumber.runtime.UnreportedStepExecutor;
 import cucumber.runtime.Utils;
 import cucumber.runtime.arquillian.api.Lambda;
 import cucumber.runtime.arquillian.container.ContextualObjectFactoryBase;
-import cucumber.runtime.arquillian.container.CukeSpaceCDIObjectFactory;
 import cucumber.runtime.arquillian.lifecycle.CucumberLifecycle;
 import cucumber.runtime.java.JavaBackend;
 import cucumber.runtime.java.StepDefAnnotation;
@@ -79,8 +78,7 @@ public class ArquillianBackend extends JavaBackend implements Backend {
         try {
             this.objectFactory = objectFactory == null ?
                     defaultObjectFactory(clazz, testInstance) :
-                    wrapObjectFactory(clazz, testInstance, "cdi".equalsIgnoreCase(objectFactory.trim()) ?
-                            new CukeSpaceCDIObjectFactory() :
+                    wrapObjectFactory(clazz, testInstance,
                             ObjectFactory.class.cast(Thread.currentThread().getContextClassLoader()
                                     .loadClass(objectFactory.trim()).getConstructor().newInstance()));
         } catch (final InstantiationException | IllegalAccessException | ClassNotFoundException | NoSuchMethodException e) {

--- a/core/src/main/java/cucumber/runtime/arquillian/client/CucumberArchiveProcessor.java
+++ b/core/src/main/java/cucumber/runtime/arquillian/client/CucumberArchiveProcessor.java
@@ -144,30 +144,35 @@ public class CucumberArchiveProcessor implements ApplicationArchiveProcessor {
         // cucumber-java and cucumber-core
         enrichWithDefaultCucumber(libraryContainer);
 
-        LibraryContainer<?> entryPointContainer = libraryContainer;
-
-        if (!archiveContains(applicationArchive, testClass.getJavaClass())) {
-            for (Node node : applicationArchive.getContent(Filters.include(".*\\.(jar|war)")).values()) {
-                if (node.getAsset() instanceof ArchiveAsset) {
-                    Archive archive = ((ArchiveAsset) node.getAsset()).getArchive();
-
-                    if (archiveContains(archive, testClass.getJavaClass()) && archive instanceof LibraryContainer) {
-                        entryPointContainer = (LibraryContainer) archive;
-                    }
-                }
-            }
-        }
+        LibraryContainer<?> entryPointContainer = (LibraryContainer<?>)findArchiveByTestClass(applicationArchive, testClass.getJavaClass());
 
         // glues
         enrichWithGlues(javaClass, entryPointContainer, ln);
 
         // cucumber-arquillian
-        enrichWithCukeSpace(entryPointContainer, junit,
-                cucumberConfiguration.getObjectFactory() != null && "cdi".equalsIgnoreCase(cucumberConfiguration.getObjectFactory().trim()));
+        enrichWithCukeSpace(entryPointContainer, junit);
 
         // if scala module is available at classpath
         final Set<ArchivePath> libs = applicationArchive.getContent(new IncludeRegExpPaths("/WEB-INF/lib/.*jar")).keySet();
         tryToAdd(libs, libraryContainer, "WEB-INF/lib/scala-library-", "cucumber.api.scala.ScalaDsl", "scala.App");
+    }
+
+    protected final Archive<? extends Archive<?>> findArchiveByTestClass(Archive<?> topArchive, Class testClass) {
+        Archive<?> testArchive = topArchive;
+
+        if (!archiveContains(testArchive, testClass)) {
+            for (Node node : testArchive.getContent(Filters.include(".*\\.(jar|war)")).values()) {
+                if (node.getAsset() instanceof ArchiveAsset) {
+                    Archive archive = ((ArchiveAsset) node.getAsset()).getArchive();
+
+                    if (archiveContains(archive, testClass) && archive instanceof LibraryContainer) {
+                        testArchive = archive;
+                    }
+                }
+            }
+        }
+
+        return testArchive;
     }
 
     private boolean archiveContains(Archive<?> archive, Class<?> clazz) {
@@ -285,7 +290,7 @@ public class CucumberArchiveProcessor implements ApplicationArchiveProcessor {
         }
     }
 
-    private static void enrichWithCukeSpace(final LibraryContainer<?> libraryContainer, final boolean junit, final boolean cdiEnabled) {
+    private static void enrichWithCukeSpace(final LibraryContainer<?> libraryContainer, final boolean junit) {
         final JavaArchive archive = create(JavaArchive.class, "cukespace-core.jar")
                 .addAsServiceProvider(RemoteLoadableExtension.class, CucumberContainerExtension.class)
                 .addPackage(ArquillianBackend.class.getPackage())
@@ -298,9 +303,6 @@ public class CucumberArchiveProcessor implements ApplicationArchiveProcessor {
                         ContextualObjectFactoryBase.class, CukeSpaceCDIObjectFactory.class)
                 .addPackage(ClientServerFiles.class.getPackage());
 
-        if (cdiEnabled) { // TODO: drop it to exclude scanning and avoid any potential issue, maybe custom extension?
-            archive.addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
-        }
         if (junit) {
             archive.addClasses(ArquillianCucumber.class, CukeSpace.class, ArquillianCucumber.InstanceControlledFrameworkMethod.class);
         } else {

--- a/core/src/main/java/cucumber/runtime/arquillian/client/CucumberArchiveProcessor.java
+++ b/core/src/main/java/cucumber/runtime/arquillian/client/CucumberArchiveProcessor.java
@@ -300,7 +300,7 @@ public class CucumberArchiveProcessor implements ApplicationArchiveProcessor {
                 .addClasses(
                         CucumberConfiguration.class, CucumberContainerExtension.class,
                         Features.class, Glues.class,
-                        ContextualObjectFactoryBase.class, CukeSpaceCDIObjectFactory.class)
+                        ContextualObjectFactoryBase.class)
                 .addPackage(ClientServerFiles.class.getPackage());
 
         if (junit) {

--- a/core/src/main/java/cucumber/runtime/arquillian/container/cdi/CDIArchiveProcessor.java
+++ b/core/src/main/java/cucumber/runtime/arquillian/container/cdi/CDIArchiveProcessor.java
@@ -1,0 +1,49 @@
+package cucumber.runtime.arquillian.container.cdi;
+
+import cucumber.runtime.arquillian.client.CucumberArchiveProcessor;
+import cucumber.runtime.arquillian.config.CucumberConfiguration;
+import cucumber.runtime.arquillian.container.CukeSpaceCDIObjectFactory;
+import java.util.Map;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.test.spi.TestClass;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ArchivePath;
+import org.jboss.shrinkwrap.api.Filters;
+import org.jboss.shrinkwrap.api.Node;
+import org.jboss.shrinkwrap.api.asset.ArchiveAsset;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+
+public class CDIArchiveProcessor extends CucumberArchiveProcessor {
+
+    @Inject
+    private Instance<CucumberConfiguration> configuration;
+
+    @Override
+    public void process(Archive<?> applicationArchive, TestClass testClass) {
+        super.process(applicationArchive, testClass);
+
+        CucumberConfiguration cucumberConfiguration = configuration.get();
+        Archive<?> entryPointContainer = findArchiveByTestClass(applicationArchive, testClass.getJavaClass());
+
+        boolean cdiEnabled = CukeSpaceCDIObjectFactory.class.getCanonicalName()
+                .equalsIgnoreCase(cucumberConfiguration.getObjectFactory().trim());
+
+        if (cdiEnabled) {
+            enrichWithCDI(entryPointContainer);
+        }
+    }
+
+    private void enrichWithCDI(Archive<?> applicationArchive) {
+        Map<ArchivePath, Node> contentMap = applicationArchive.getContent(Filters.include(".*/cukespace-core.jar"));
+        for (Node node : contentMap.values()) {
+            if (node.getAsset() instanceof ArchiveAsset) {
+                JavaArchive archive = (JavaArchive) ((ArchiveAsset) node.getAsset()).getArchive();
+
+                archive.addClass(CukeSpaceCDIObjectFactory.class);
+                archive.addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+            }
+        }
+    }
+}

--- a/core/src/main/java/cucumber/runtime/arquillian/container/cdi/CDIArchiveProcessor.java
+++ b/core/src/main/java/cucumber/runtime/arquillian/container/cdi/CDIArchiveProcessor.java
@@ -25,12 +25,12 @@ public class CDIArchiveProcessor extends CucumberArchiveProcessor {
         super.process(applicationArchive, testClass);
 
         CucumberConfiguration cucumberConfiguration = configuration.get();
-        Archive<?> entryPointContainer = findArchiveByTestClass(applicationArchive, testClass.getJavaClass());
 
         boolean cdiEnabled = CukeSpaceCDIObjectFactory.class.getCanonicalName()
                 .equalsIgnoreCase(cucumberConfiguration.getObjectFactory().trim());
 
         if (cdiEnabled) {
+            Archive<?> entryPointContainer = findArchiveByTestClass(applicationArchive, testClass.getJavaClass());
             enrichWithCDI(entryPointContainer);
         }
     }

--- a/core/src/main/java/cucumber/runtime/arquillian/container/cdi/CDIConfigurationObserver.java
+++ b/core/src/main/java/cucumber/runtime/arquillian/container/cdi/CDIConfigurationObserver.java
@@ -1,0 +1,22 @@
+package cucumber.runtime.arquillian.container.cdi;
+
+import cucumber.runtime.arquillian.config.CucumberConfiguration;
+import cucumber.runtime.arquillian.container.CukeSpaceCDIObjectFactory;
+import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.api.annotation.Observes;
+
+public class CDIConfigurationObserver {
+    @Inject
+    private Instance<CucumberConfiguration> configuration;
+    
+    public void findConfiguration(final @Observes(precedence = -10) ArquillianDescriptor descriptor) {
+        CucumberConfiguration cucumberConfiguration = configuration.get();
+        String objectFactory = cucumberConfiguration.getObjectFactory();
+        
+        if ("cdi".equalsIgnoreCase(objectFactory)) {
+            cucumberConfiguration.setObjectFactory(CukeSpaceCDIObjectFactory.class.getCanonicalName());
+        }
+    }
+}

--- a/core/src/main/java/cucumber/runtime/arquillian/container/cdi/CDIExtension.java
+++ b/core/src/main/java/cucumber/runtime/arquillian/container/cdi/CDIExtension.java
@@ -1,0 +1,15 @@
+package cucumber.runtime.arquillian.container.cdi;
+
+import cucumber.runtime.arquillian.client.CucumberArchiveProcessor;
+import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+
+public class CDIExtension implements LoadableExtension {
+
+    @Override
+    public void register(ExtensionBuilder builder) {
+        builder.override(ApplicationArchiveProcessor.class, CucumberArchiveProcessor.class, CDIArchiveProcessor.class)
+                .observer(CDIConfigurationObserver.class);
+    }
+
+}

--- a/core/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/core/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,1 +1,2 @@
 cucumber.runtime.arquillian.client.CucumberClientExtension
+cucumber.runtime.arquillian.container.cdi.CDIExtension


### PR DESCRIPTION
I made the CDI more as an extension.
I removed the `CukeSpaceCDIObjectFactory` and `beans.xml` specifics and moved it out. 

For the CDIExtensionBuilder I used `.override`, because when I use service the order of archive processing is random, thus I can't guarantee that core.jar is already there.